### PR TITLE
Included the Response Class to replace JsonResponse because of localh…

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This will create two new files for you; a controller located in `src/Controller/
 namespace App\Controller;
     
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
     
 class DefaultController extends AbstractController


### PR DESCRIPTION
…ost cross-domain errors.

Hey @yemiwebby because we're running this on localhost, I replaced the JsonResponse class implementation because of Cross-Domain Origin errors. By using the Response class I could define the header to support a wildcard. 